### PR TITLE
Recode object keys in Legacy Core bucket

### DIFF
--- a/R/get_data_helpers.R
+++ b/R/get_data_helpers.R
@@ -106,9 +106,9 @@ core_file_constructor <- function(time,
                                   scope.orgtype,
                                   scope.formtype){
   # Organization Type dictionary
-  orgtype_dic <- c("CHARITIES" = "CHARITIES-SCOPE-501C3",
-                   "PRIVFOUND" = "PRIVFOUND-SCOPE-501C3",
-                   "NONPROFIT" = "NONPROFIT-SCOPE-501CE")
+  orgtype_dic <- c("CHARITIES" = "501C3-CHARITIES",
+                   "PRIVFOUND" = "501C3-PRIVFOUND",
+                   "NONPROFIT" = "501CE-NONPROFIT")
 
   # Base names
   root_file <- "CORE-"

--- a/data-raw/data_generation.R
+++ b/data-raw/data_generation.R
@@ -135,7 +135,7 @@ ntee_preproc <- function(path_to_csv = "data-raw/ntee-disaggregated.csv"){
 
 # Function to generate size dictionary
 
-s3_metadata <- read.csv("data-raw/AWS-NCCSDATA.csv")
+s3_metadata <- read.csv("https://raw.githubusercontent.com/UrbanInstitute/nccs/main/catalogs/AWS-NCCSDATA.csv")
 s3_metadata$url <- paste0("https://nccsdata.s3.amazonaws.com/",
                           s3_metadata$Key)
 


### PR DESCRIPTION
This commit edits the core_file_constructor() and R scripts in data_generation.R to read in the renamed legacy core objects on S3. The objects were renamed to improve readability by removing the redundant "SCOPE" string from file names. Thus, nccsdata's get_data() had to be debugged to read from the correct S3 urls pointing to the renamed object keys. Additionally, the internal named list used to store object keys had to be reconstructed as well to account for the renamed keys.