### PR TITLE
ci: add contracts-guard caller (ADR 0022)

### DIFF
--- a/.github/workflows/contracts-guard.yml
+++ b/.github/workflows/contracts-guard.yml
@@ -1,0 +1,25 @@
+name: contracts-guard
+
+# Thin caller of the reusable contract-change guard in nccs-contracts (ADR 0022).
+# The guard logic lives once there; this file passes only this repo's
+# paths_regex. nccsdata is a CONSUMER, so the contract-relevant surface is how
+# it READS and PINS contracted artifacts — the read/url/vintage/catalog/column
+# code. Tune the regex as that surface evolves.
+#
+# The guard verifies ACKNOWLEDGMENT, not correctness: a PR that touches the
+# matched paths must carry an `ADR NNNN` breadcrumb (commit message or PR body)
+# or the `contracts-ack` label, so the nccs-contracts reconcile isn't silently
+# skipped. See nccs-contracts/CONTRIBUTING.md.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  contracts-guard:
+    uses: UrbanInstitute/nccs-contracts/.github/workflows/contracts-guard.yml@main
+    with:
+      paths_regex: '^R/nccs_(read|read_core|vintage_url|core_url|catalog|core_columns|core_coverage)\.R$'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,3 +206,17 @@ Tests use testthat edition 3. Network-dependent integration tests use `skip_on_c
 - `test-nccs_read.R` — S3 path construction, input validation (offline), integration reads (network)
 - `test-nccs_normalize_ein.R` — EIN coercion happy/edge paths (offline)
 - `test-nccs_as_indicator.R` — yn/efile coercion, unknown-value warning (offline)
+
+## Contract-change guard (ADR 0022)
+
+A PR that changes how this package **reads or pins** contracted artifacts — the
+read/url/vintage/catalog/column code — must acknowledge the
+[`nccs-contracts`](https://github.com/UrbanInstitute/nccs-contracts) impact, or
+CI fails. The `.github/workflows/contracts-guard.yml` caller (a thin wrapper
+over the reusable guard in `nccs-contracts`) fires on PRs that change
+`R/nccs_read*.R`, `R/nccs_vintage_url.R`, `R/nccs_core_url.R`,
+`R/nccs_catalog.R`, or `R/nccs_core_columns.R`/`R/nccs_core_coverage.R`. To
+pass: add an `ADR NNNN` breadcrumb to a commit message or the PR body (and queue
+the `nccs-contracts` reconcile if a contract pin/version moved), **or** add the
+`contracts-ack` label if there's genuinely no contract impact. The guard checks
+*acknowledgment, not correctness*.


### PR DESCRIPTION
Adds the thin caller of the reusable contract-change guard in `nccs-contracts` (ADR 0022, Migration step 3) + a `CLAUDE.md` pointer.

`nccsdata` is a **consumer**, so the guard fires on changes to how it reads/pins contracted artifacts.

**`paths_regex`:** `^R/nccs_(read|read_core|vintage_url|core_url|catalog|core_columns|core_coverage)\.R$` — the read / url / vintage / catalog / column-expectation surface.

Verifies **acknowledgment, not correctness**: a matching PR must carry an `ADR NNNN` breadcrumb or the `contracts-ack` label. Always runs, passes when irrelevant — safe to mark required.

ADR 0022

🤖 Generated with [Claude Code](https://claude.com/claude-code)