### PR TITLE
docs(vignette): correct stale nccs_catalog() example output

### DIFF
--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -49,9 +49,16 @@ nccs_dictionary("ntee")
 Use `nccs_catalog()` to see the valid values for each filter before querying:
 
 ```{r}
-# NTEE v2 subsector codes
+# NTEE v2 subsectors. For fields where a bare code is opaque, each value is
+# returned as an inline "CODE - Description" string (accepted back verbatim by
+# nccs_read()). Pass labels = TRUE for a code + description tibble instead.
 nccs_catalog("ntee_subsector")
-#> [1] "ART" "EDU" "ENV" "HEL" "HMS" "HOS" "IFA" "MMB" "PSB" "REL" "UNI" "UNU"
+#>  [1] "ART - Arts, Culture, and Humanities"  "EDU - Education"
+#>  [3] "ENV - Environment and Animals"        "HEL - Health"
+#>  [5] "HMS - Human Services"                 "IFA - International, Foreign Affairs"
+#>  [7] "PSB - Public, Societal Benefit"       "REL - Religion Related"
+#>  [9] "MMB - Mutual/Membership Benefit"      "UNU - Unknown, Unclassified"
+#> [11] "UNI - Universities"                   "HOS - Hospitals"
 
 # State and territory codes
 nccs_catalog("state")


### PR DESCRIPTION
The getting-started vignette showed `nccs_catalog("ntee_subsector")`
returning bare codes (`"ART" "EDU" …`), but the function returns inline
`"CODE - Description"` strings by default for fields where a bare code is
opaque (`R/nccs_catalog.R:47-55`). This corrects the example's `#>` output
to match actual behavior, verified against `devtools::load_all()`, and
notes the `labels = TRUE` tibble alternative.

Pre-existing doc drift surfaced while smoke-testing the EIN bridge (#22);
no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)